### PR TITLE
按composer规范代码重构，编写单元测试，支持laravel包调用，具体见更新后的README.md后半部分

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
-/vendor/
 /.idea/
+composer.phar
+/vendor/
+
+# Commit your application's lock file http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
+# You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,26 +1,43 @@
 {
     "name": "quickj/dubbo-php-client",
     "description": "dubbo php client",
+    "type": "library",
     "authors": [
         {
             "name": "jquick",
             "email": "314127900@qq.com"
+        },
+        {
+            "name": "nick fan",
+            "email": "nickfan81@gmail.com"
         }
     ],
-    "require": {
-    },
     "minimum-stability": "dev",
+    "require": {
+        "php": ">=5.5.9",
+        "ext-zookeeper": "*",
+        "guzzlehttp/guzzle": "~5.3|~6.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~4.0"
+    },
     "autoload": {
         "psr-4": {
-            "dubbo\\":"src",
-            "dubbo\\invok\\":"src/invok",
-            "dubbo\\protocols\\":"src/invok/protocols"
+            "dubbo\\":"src/",
+            "dubbo\\invok\\":"src/invok/",
+            "dubbo\\protocols\\":"src/invok/protocols/",
+            "DubboPhp\\Client\\": "src/DubboPhp/Client/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "DubboPhp\\Client\\Tests\\": "tests/"
         }
     },
     "repositories": {
-    	"packagist": {
-        	"type": "composer",
-        	"url": "https://packagist.phpcomposer.com"
-    	}
-}
+        "packagist": {
+            "type": "composer",
+            "url": "https://packagist.phpcomposer.com"
+        }
+    }
 }

--- a/example_composer.php
+++ b/example_composer.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: user
+ * Date: 2017/3/9
+ * Time: 20:31
+ */
+
+require_once __DIR__.'/vendor/autoload.php';
+
+use DubboPhp\Client\Client;
+
+$options = [
+    'registry_address' => '127.0.0.1:2181',
+    'version' => '1.0.0',
+    'group' =>null,
+    'protocol' => 'jsonrpc'
+];
+
+try {
+    $dubboCli = new Client($options);
+    $testService = $dubboCli->getService("com.dubbo.demo.HelloService");
+    $ret = $testService->hello("dubbo php client");
+    var_dump($ret);
+    $mapRet = $testService->mapEcho();
+    var_dump($mapRet);
+
+    $objectRet = $testService->objectEcho();
+    var_dump($objectRet);
+
+    /**
+     * getService method support 2 way. If the forceVgp = true, It will assign the function parameter to service version,group and protocol. Default way is assign the $options configs to these.
+     * getService支持两种方式调用。如果forceVgp=true, 该方法将使用传参来绑定服务的版本号，组和协议。默认方式是使用$options数组里的配置绑定。
+     */
+    $testServiceWithvgp = $dubboCli->getService("com.dubbo.demo.HelloService","1.0.0",null, $forceVgp = true);
+    $vgpRet = $testServiceWithvgp->hello("this request from vgp");
+    var_dump($vgpRet);
+} catch (\Exception $e) {
+    print($e->getMessage());
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         verbose="true"
+        >
+    <testsuites>
+        <testsuite name="Package Test Suite">
+            <directory suffix=".php">./tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/DubboPhp/Client/Client.php
+++ b/src/DubboPhp/Client/Client.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: user
+ * Date: 2017/3/8
+ * Time: 17:06
+ */
+
+namespace DubboPhp\Client;
+
+
+class Client
+{
+    const VERSION_DEFAULT = '0.0.0';
+    const PROTOCOL_JSONRPC = 'jsonrpc';
+    const PROTOCOL_HESSIAN = 'hessian';
+
+    /**
+     * @var Register
+     */
+    protected $register;
+    protected static $protocolSupports = [
+        self::PROTOCOL_JSONRPC => true,
+        self::PROTOCOL_HESSIAN => false,
+    ];
+    protected static $protocols = [
+    ];
+
+    /**
+     * Client constructor.
+     * @param array $options
+     */
+    public function __construct($options = [])
+    {
+        $this->register = new Register($options);
+    }
+
+    public function factory($options=[]){
+        return new static($options);
+    }
+
+    /**
+     * @param $serviceName  (service name e.g. com.xx.serviceName)
+     * @param $version  (service version e.g. 1.0)
+     * @param $group    (service group)
+     * @param string $protocol (service protocol e.g. jsonrpc dubbo hessian)
+     * @return get| specific dubbo service with your params
+     */
+    public function getService($serviceName, $version = self::VERSION_DEFAULT, $group = null, $protocol = self::PROTOCOL_JSONRPC, $forceVgp = false){
+        $serviceVersion = !$forceVgp ? $this->register->getServiceVersion() : $version;
+        $serviceGroup = !$forceVgp ? $this->register->getServiceGroup() : $group;
+        $serviceProtocol = !$forceVgp ? $this->register->getServiceProtocol() : $protocol;
+
+        $invokerDesc = new InvokerDesc($serviceName, $serviceVersion, $serviceGroup);
+        $invoker = $this->register->getInvoker($invokerDesc);
+        if(!$invoker){
+            $invoker = $this->makeInvokerByProtocol($serviceProtocol);
+            $this->register->register($invokerDesc,$invoker);
+        }
+        return $invoker;
+    }
+
+    /**
+     * @param $protocol
+     * @return Invoker instance of specific protocol
+     * @throws \DubboPhp\Client\DubboPhpException
+     */
+    private function makeInvokerByProtocol($protocol=self::PROTOCOL_JSONRPC,$url=null, $debug=false){
+        if(!isset(self::$protocolSupports[$protocol]) || self::$protocolSupports[$protocol]!=true){
+            throw new DubboPhpException('Protocol Not Supported yet.');
+        }
+        if(!isset(self::$protocols[$protocol])){
+            $providerName = 'DubboPhp\\Client\\Protocols\\'.ucfirst($protocol);
+            self::$protocols[$protocol] = new $providerName($url,$debug);
+        }
+        return self::$protocols[$protocol];
+    }
+
+}

--- a/src/DubboPhp/Client/Client.php
+++ b/src/DubboPhp/Client/Client.php
@@ -44,7 +44,7 @@ class Client
      * @param $version  (service version e.g. 1.0)
      * @param $group    (service group)
      * @param string $protocol (service protocol e.g. jsonrpc dubbo hessian)
-     * @return get| specific dubbo service with your params
+     * @return Invoker
      */
     public function getService($serviceName, $version = self::VERSION_DEFAULT, $group = null, $protocol = self::PROTOCOL_JSONRPC, $forceVgp = false){
         $serviceVersion = !$forceVgp ? $this->register->getServiceVersion() : $version;

--- a/src/DubboPhp/Client/Cluster.php
+++ b/src/DubboPhp/Client/Cluster.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: user
+ * Date: 2017/3/8
+ * Time: 17:42
+ */
+
+namespace DubboPhp\Client;
+
+
+class Cluster
+{
+    protected static $providerMap = [];
+    private static $_instance;
+
+    private function __construct(){
+    }
+
+    private function __clone(){
+
+    }
+
+    public static function getInstance(){
+        if(!(self::$_instance instanceof self)){
+            self::$_instance = new static();
+        }
+        return self::$_instance;
+    }
+
+    public function addProvider(InvokerDesc $invokerDesc,$host){
+        $desc = $invokerDesc->toString();
+        self::$providerMap[$desc][] = $host;
+    }
+
+
+    public function getProvider(InvokerDesc $invokerDesc){
+        $desc = $invokerDesc->toString();
+        if(!isset(self::$providerMap[$desc])){
+            $invokerArr = explode('_', $desc);
+            throw new DubboPhpException('Request Service Error: Can not find your service.Please Check your service name,version and group.'."\n".'RequestServiceName: '.$invokerArr[0]."\n".'RequestServiceGroup: '.$invokerArr[1]."\n".'RequestServiceVersion: '.$invokerArr[2]."\n".'RequestServiceProtocol: '.$invokerArr[3]."\n");
+        }
+        $key = array_rand(self::$providerMap[$desc]);
+        return self::$providerMap[$desc][$key];
+    }
+
+    public function getProviders(){
+        return self::$providerMap;
+    }
+
+}

--- a/src/DubboPhp/Client/Cluster.php
+++ b/src/DubboPhp/Client/Cluster.php
@@ -38,7 +38,7 @@ class Cluster
         $desc = $invokerDesc->toString();
         if(!isset(self::$providerMap[$desc])){
             $invokerArr = explode('_', $desc);
-            throw new DubboPhpException('Request Service Error: Can not find your service.Please Check your service name,version and group.'."\n".'RequestServiceName: '.$invokerArr[0]."\n".'RequestServiceGroup: '.$invokerArr[1]."\n".'RequestServiceVersion: '.$invokerArr[2]."\n".'RequestServiceProtocol: '.$invokerArr[3]."\n");
+            throw new DubboPhpException('Request Service Error: Can not find your service.Please Check your service name,version and group.'.PHP_EOL.'RequestServiceName: '.$invokerArr[0].PHP_EOL.'RequestServiceGroup: '.$invokerArr[1].PHP_EOL.'RequestServiceVersion: '.$invokerArr[2].PHP_EOL.'RequestServiceProtocol: '.$invokerArr[3].PHP_EOL);
         }
         $key = array_rand(self::$providerMap[$desc]);
         return self::$providerMap[$desc][$key];

--- a/src/DubboPhp/Client/DubboPhpClientServiceProvider.php
+++ b/src/DubboPhp/Client/DubboPhpClientServiceProvider.php
@@ -28,7 +28,7 @@ class DubboPhpClientServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $source = dirname(__DIR__).'/config/config.php';
+        $source = dirname(dirname(__DIR__)).'/config/config.php';
 
         if ($this->app instanceof LaravelApplication && $this->app->runningInConsole()) {
             $this->publishes([$source => config_path('dubbo_cli.php')]);

--- a/src/DubboPhp/Client/DubboPhpClientServiceProvider.php
+++ b/src/DubboPhp/Client/DubboPhpClientServiceProvider.php
@@ -53,8 +53,8 @@ class DubboPhpClientServiceProvider extends ServiceProvider
         });
         $this->app->alias('dubbo_cli.factory', 'DubboPhp\Client\Client');
         $this->app->alias('dubbo_cli', 'DubboPhp\Client\Client');
-        $this->app->alias('DubboPhpClient', 'DubboPhp\Client\Facades\DubboPhpClient');
-        $this->app->alias('DubboPhpClientFactory', 'DubboPhp\Client\Facades\DubboPhpClientFactory');
+//        $this->app->alias('DubboPhpClient', 'DubboPhp\Client\Facades\DubboPhpClient');
+//        $this->app->alias('DubboPhpClientFactory', 'DubboPhp\Client\Facades\DubboPhpClientFactory');
     }
 
     /**
@@ -64,7 +64,10 @@ class DubboPhpClientServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return ['dubbo_cli', 'dubbo_cli.factory','DubboPhpClient','DubboPhpClientFactory'];
+        return [
+            'dubbo_cli', 'dubbo_cli.factory',
+//            'DubboPhpClient','DubboPhpClientFactory'
+        ];
     }
 
 }

--- a/src/DubboPhp/Client/DubboPhpClientServiceProvider.php
+++ b/src/DubboPhp/Client/DubboPhpClientServiceProvider.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: user
+ * Date: 2017/3/8
+ * Time: 17:06
+ */
+
+namespace DubboPhp\Client;
+
+use Illuminate\Support\ServiceProvider;
+
+use Illuminate\Foundation\Application as LaravelApplication;
+use Laravel\Lumen\Application as LumenApplication;
+
+class DubboPhpClientServiceProvider extends ServiceProvider
+{
+
+    /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = false;
+
+    /**
+     * Bootstrap the application events.
+     */
+    public function boot()
+    {
+        $source = dirname(__DIR__).'/config/config.php';
+
+        if ($this->app instanceof LaravelApplication && $this->app->runningInConsole()) {
+            $this->publishes([$source => config_path('dubbo_cli.php')]);
+        } elseif ($this->app instanceof LumenApplication) {
+            $this->app->configure('dubbo_cli');
+        }
+
+        $this->mergeConfigFrom($source, 'dubbo_cli');
+    }
+
+    /**
+     * Register the service provider.
+     */
+    public function register()
+    {
+        $this->app->bind('dubbo_cli.factory', function ($app,$parameters=[]) {
+            $parameters+=$app['config']->get('dubbo_cli.default',[]);
+            return new Client($parameters);
+        });
+        $this->app->singleton('dubbo_cli',function($app){
+            return new Client($app['config']->get('dubbo_cli.default',[]));
+        });
+        $this->app->alias('dubbo_cli.factory', 'DubboPhp\Client\Client');
+        $this->app->alias('dubbo_cli', 'DubboPhp\Client\Client');
+        $this->app->alias('DubboPhpClient', 'DubboPhp\Client\Facades\DubboPhpClient');
+        $this->app->alias('DubboPhpClientFactory', 'DubboPhp\Client\Facades\DubboPhpClientFactory');
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return ['dubbo_cli', 'dubbo_cli.factory','DubboPhpClient','DubboPhpClientFactory'];
+    }
+
+}

--- a/src/DubboPhp/Client/DubboPhpException.php
+++ b/src/DubboPhp/Client/DubboPhpException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: user
+ * Date: 2017/3/8
+ * Time: 17:05
+ */
+
+namespace DubboPhp\Client;
+
+
+class DubboPhpException extends \Exception
+{
+
+}

--- a/src/DubboPhp/Client/Facades/DubboPhpClient.php
+++ b/src/DubboPhp/Client/Facades/DubboPhpClient.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Description
+ *
+ * @project mulsite
+ * @package mulsite
+ * @author nickfan <nickfan81@gmail.com>
+ * @link http://www.axiong.me
+ * @version $Id$
+ * @lastmodified: 2015-09-21 09:12
+ *
+ */
+
+namespace DubboPhp\Client\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+class DubboPhpClient extends Facade {
+
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+//        return 'DubboPhp\Client\DubboPhpClient';
+        return 'dubbo_cli';
+    }
+
+}

--- a/src/DubboPhp/Client/Facades/DubboPhpClientFactory.php
+++ b/src/DubboPhp/Client/Facades/DubboPhpClientFactory.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Description
+ *
+ * @project mulsite
+ * @package mulsite
+ * @author nickfan <nickfan81@gmail.com>
+ * @link http://www.axiong.me
+ * @version $Id$
+ * @lastmodified: 2015-09-21 09:12
+ *
+ */
+
+namespace DubboPhp\Client\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+class DubboPhpClientFactory extends Facade {
+
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+//        return 'DubboPhp\Client\DubboPhpClientFactory';
+        return 'dubbo_cli.factory';
+    }
+
+}

--- a/src/DubboPhp/Client/Invoker.php
+++ b/src/DubboPhp/Client/Invoker.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: user
+ * Date: 2017/3/8
+ * Time: 17:40
+ */
+
+namespace DubboPhp\Client;
+
+
+abstract class Invoker{
+    protected $invokerDesc;
+    protected $url;
+    protected $id = 0;
+    protected $debug;
+    protected $notification = false;
+    protected $cluster;
+    public function __construct($url=null, $debug=false) {
+        // server URL
+        $this->url = $url;
+        $this->debug;
+        $this->cluster = Cluster::getInstance();
+    }
+    public function setRPCNotification($notification = true) {
+        $this->notification = (bool) $notification;
+        return $this;
+    }
+
+    public function getCluster(){
+        return $this->cluster;
+    }
+
+    public function setHost($url){
+        $this->url = $url;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     * @return Invoker
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    public static function genDubboUrl($host,$invokerDesc){
+        return $host.'/'.$invokerDesc->getService();
+    }
+
+    public function toString(){
+        return  __CLASS__;
+    }
+
+    public function __toString()
+    {
+        return $this->toString();
+    }
+
+    abstract public function __call($name,$arguments);
+
+}

--- a/src/DubboPhp/Client/InvokerDesc.php
+++ b/src/DubboPhp/Client/InvokerDesc.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: user
+ * Date: 2017/3/8
+ * Time: 17:36
+ */
+
+namespace DubboPhp\Client;
+
+
+class InvokerDesc
+{
+    private $serviceName ;
+    private $group ;
+    private $version ;
+    private $schema = 'jsonrpc';
+
+    public function __construct($serviceName, $version=null, $group=null){
+        $this->serviceName = $serviceName ;
+        $this->version = $version;
+        $this->group = $group;
+    }
+
+    public function getService(){
+        return $this->serviceName;
+    }
+
+    public function __toString()
+    {
+        return $this->toString();
+    }
+
+    public function toString(){
+        $group_str = !is_null($this->group) ? $this->group : ' ';
+        $version_str = !is_null($this->version) ? $this->version : ' ';
+        return $this->serviceName.'_'.$group_str.'_'.$version_str.'_'.$this->schema;
+    }
+
+    public function isMatch($group,$version){
+        return $this->group === $group && $this->version === $version;
+    }
+
+    public function isMatchDesc($desc){
+        return $this->group == $desc->group && $this->version == $desc->version;
+    }
+
+}

--- a/src/DubboPhp/Client/Protocols/Hessian.php
+++ b/src/DubboPhp/Client/Protocols/Hessian.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: user
+ * Date: 2017/3/8
+ * Time: 17:48
+ */
+
+namespace DubboPhp\Client\Protocols;
+
+use DubboPhp\Client\DubboPhpException;
+use DubboPhp\Client\Invoker;
+
+class Hessian extends Invoker
+{
+    public function __construct($url=null, $debug=false)
+    {
+        parent::__construct($url,$debug);
+    }
+
+    public function __call($name, $arguments)
+    {
+        //@todo implement method
+        throw new DubboPhpException('Protocol not implemented yet.');
+
+        if (!is_scalar($name)) {
+            throw new DubboPhpException('Method name has no scalar value');
+        }
+
+        // check
+        if (is_array($arguments)) {
+            // no keys
+            $params = array_values($arguments);
+        } else {
+            throw new DubboPhpException('Params must be given as array');
+        }
+
+        // sets notification or request task
+        if ($this->notification) {
+            $currentId = NULL;
+        } else {
+            $currentId = $this->id;
+            $this->id++;
+        }
+        return null;
+    }
+
+}

--- a/src/DubboPhp/Client/Protocols/Jsonrpc.php
+++ b/src/DubboPhp/Client/Protocols/Jsonrpc.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: user
+ * Date: 2017/3/8
+ * Time: 17:48
+ */
+
+namespace DubboPhp\Client\Protocols;
+
+use DubboPhp\Client\DubboPhpException;
+use DubboPhp\Client\Invoker;
+
+class Jsonrpc extends Invoker{
+
+    public function __construct($url=null, $debug=false)
+    {
+        parent::__construct($url,$debug);
+    }
+
+    public function __call($name, $arguments)
+    {
+        if (!is_scalar($name)) {
+            throw new DubboPhpException('Method name has no scalar value');
+        }
+
+        // check
+        if (is_array($arguments)) {
+            // no keys
+            $params = array_values($arguments);
+        } else {
+            throw new DubboPhpException('Params must be given as array');
+        }
+
+        // sets notification or request task
+        if ($this->notification) {
+            $currentId = NULL;
+        } else {
+            $currentId = $this->id;
+            $this->id++;
+        }
+
+        // prepares the request
+        $request = array(
+            'method' => $name,
+            'params' => $params,
+            'id' => $currentId
+        );
+        $request = json_encode($request);
+        $this->debug && $this->debug.='***** Request *****'."\n".$request."\n".'***** End Of request *****'."\n\n";
+
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $this->url);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-type: application/json'));
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+        curl_setopt($ch, CURLOPT_POST, TRUE);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $request);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
+
+        $responseContent = curl_exec($ch);
+        $curlErrorCode = curl_errno($ch);
+        $curlErrorMessage = curl_error($ch);
+        curl_close($ch);
+        if ($responseContent === FALSE)  {
+            throw new DubboPhpException('Unable to connect to '.$this->url.' :'.$curlErrorMessage,$curlErrorCode);
+        }
+
+        $response = json_decode($responseContent,true);
+        $jsonDecodeErrorCode = json_last_error();
+        if($jsonDecodeErrorCode!==JSON_ERROR_NONE){
+            $jsonDecodeErrorMessage = json_last_error_msg();
+            throw new DubboPhpException('Unable to decode response content: '.$jsonDecodeErrorMessage.' :'.$responseContent,$jsonDecodeErrorCode);
+        }
+
+
+        // debug output
+        if ($this->debug) {
+            //echo nl2br($debug);
+        }
+
+        // final checks and return
+        if (!$this->notification) {
+            // check
+            if ($response['id'] != $currentId) {
+                throw new DubboPhpException('Incorrect response id (request id: '.$currentId.', response id: '.$response['id'].')');
+            }
+            if (isset($response['error'])) {
+                //var_dump($response);
+                $responseErrorCode = isset($response['error']['code'])?$response['error']['code']:0;
+                $responseErrorMessage = isset($response['error']['message'])?$response['error']['message']:'';
+                throw new DubboPhpException('Response error: '.$responseErrorMessage,$responseErrorCode);
+            }
+            return $response['result'];
+
+        } else {
+            return true;
+        }
+    }
+
+}

--- a/src/DubboPhp/Client/Register.php
+++ b/src/DubboPhp/Client/Register.php
@@ -1,0 +1,257 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: user
+ * Date: 2017/3/8
+ * Time: 17:25
+ */
+
+namespace DubboPhp\Client;
+
+
+class Register
+{
+
+    public $config = [
+        'registry_address' => '127.0.0.1:2181',
+        'provider_timeout' => 5, //seconds
+        'version' => Client::VERSION_DEFAULT,
+        'group' => null,
+        'protocol' => Client::PROTOCOL_JSONRPC,
+    ];
+
+    public $zookeeper = null;
+
+    protected $ip = null;
+
+    /**
+     * @var Cluster
+     */
+    protected $providersCluster;
+
+    public static $ServiceMap = [];
+
+    protected $acl = [
+        [
+            'perms' => \Zookeeper::PERM_ALL,
+            'scheme' => 'world',
+            'id' => 'anyone'
+        ]
+    ];
+
+    public function __construct($options = [])
+    {
+        $this->config = array_merge($this->config, $options);
+        $this->ip = $this->achieveRegisterIp();
+        $this->providersCluster = Cluster::getInstance();
+        $this->zookeeper = $this->makeZookeeper($this->config['registry_address']);
+    }
+
+    private function makeZookeeper($registry_address)
+    {
+        return new \Zookeeper ($registry_address);
+    }
+
+    public function subscribe(InvokerDesc $invokDesc)
+    {
+        $desc = $invokDesc->toString();
+        $serviceName = $invokDesc->getService();
+
+        $path = $this->getSubscribePath($serviceName);
+        $children = $this->zookeeper->getChildren($path);
+        if (count($children) > 0) {
+            foreach ($children as $key => $provider) {
+                $provider = urldecode($provider);
+                $this->methodChangeHandler($invokDesc, $provider);
+            }
+            $this->configurators();
+        }
+    }
+
+    /**
+     * @param InvokerDesc $invokDesc
+     * @param $invoker
+     * @return bool
+     * Register consumer information node to the zookeeper.
+     */
+    public function register(InvokerDesc $invokDesc, Invoker $invoker)
+    {
+        $desc = $invokDesc->toString();
+        if (!isset(self::$ServiceMap[$desc])){
+            self::$ServiceMap[$desc] = $invoker;
+        }
+        $this->subscribe($invokDesc);
+        $providerHost = $this->providersCluster->getProvider($invokDesc);
+        $invoker->setHost(Invoker::genDubboUrl($providerHost, $invokDesc));
+        $registerNode = $this->makeRegistryNode($invokDesc->getService());
+        try {
+            $parts = explode('/', $registerNode);
+            $parts = array_filter($parts);
+            $subpath = '';
+            while (count($parts) > 1) {
+                $subpath .= '/' . array_shift($parts);
+                if (!$this->zookeeper->exists($subpath)) {
+                    $this->zookeeper->create($subpath, '', $this->acl, null);
+                }
+            }
+            if (!$this->zookeeper->exists($registerNode)) {
+                $this->zookeeper->create($registerNode, '', $this->acl, null);
+            }
+        }catch (\ZookeeperNoNodeException $ze){
+            throw new DubboPhpException('This zookeeper node does not exsit.Please check the zookeeper node information.',0,$ze);
+//            error_log("This zookeeper node does not exsit.Please check the zookeeper node information.");
+        }
+        return true;
+    }
+
+
+    public function methodChangeHandler(InvokerDesc $invokerDesc, $provider)
+    {
+        $schemeInfo = parse_url($provider);
+        $providerConfig = array();
+        parse_str($schemeInfo['query'], $providerConfig);
+        $group = isset($providerConfig['group']) ? $providerConfig['group'] : null;
+        $version = isset($providerConfig['version']) ? $providerConfig['version'] : null;
+        if ($invokerDesc->isMatch($group, $version)) {
+            $this->providersCluster->addProvider($invokerDesc,
+                'http://' . $schemeInfo['host'] . ':' . $schemeInfo['port'], $schemeInfo['scheme']);
+        }
+    }
+
+
+    public function getInvoker(InvokerDesc $invokerDesc)
+    {
+        $desc = $invokerDesc->toString();
+        if (!isset(self::$ServiceMap[$desc])) {
+            return null;
+        }
+        return self::$ServiceMap[$desc];
+    }
+
+
+    public function configurators()
+    {
+        return true;
+    }
+
+
+    protected function getSubscribePath($serviceName)
+    {
+        return '/dubbo/' . $serviceName . '/providers';
+    }
+
+    protected function getRegistryAddress()
+    {
+        return $this->config['registry_address'];
+    }
+
+    public function getServiceVersion()
+    {
+        return $this->config['version'];
+    }
+
+    public function getServiceGroup()
+    {
+        return $this->config['group'];
+    }
+
+    public function getServiceProtocol()
+    {
+        return $this->config['protocol'];
+    }
+
+
+    /**
+     * @param $serviceName
+     * @param array $application
+     * @return string
+     * Make a dubbo consumer address for this node which want register itself under the dubbo service
+     *
+     */
+    private function makeRegistryNode($serviceName, $application = [])
+    {
+        $params = http_build_query($application);
+        $url = '/dubbo/' . $serviceName . '/consumers/' . urlencode('consumer://' . $this->ip . '/' . $serviceName . '?') . $params;
+        return $url;
+    }
+
+
+    /**
+     * @param $serviceName
+     * @param array $application
+     * @return string
+     */
+    private function makeRegistryPath($serviceName, $application = [])
+    {
+        $params = http_build_query($application);
+        $path = '/dubbo/' . $serviceName . '/consumers';
+        return $path;
+    }
+
+
+    protected function getConfiguratorsPath($serviceName)
+    {
+        return '/dubbo/' . $serviceName . '/configurators';
+    }
+
+    protected function getProviderTimeout()
+    {
+        return $this->config['provider_timeout'] * 1000;
+    }
+
+
+    public function zkinfo(InvokerDesc $invokerDesc)
+    {
+        //@todo dump zkinfo
+//        echo $this->getRegistryPath($invokerDesc->getService());
+//        var_dump($this->providersCluster->getProviders());
+//        var_dump($this->providersCluster);
+    }
+
+
+    /**
+     * @param string $ip
+     * @return Register
+     */
+    public function setIp($ip)
+    {
+        $this->ip = $ip;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIp()
+    {
+        return $this->ip;
+    }
+
+    /**
+     * @return string
+     * @throws \DubboPhp\Client\DubboPhpException
+     * Get the consumer server local ip. If we can't get the ip from the environments,
+     * we will get from the command.
+     */
+    private function achieveRegisterIp()
+    {
+        $registerIp = null;
+        if (php_sapi_name() == 'cli') {
+            if (substr(strtolower(PHP_OS), 0, 3) != 'win') {
+                $command = "/sbin/ifconfig eth0 2>&1 | grep 'inet' | cut -d: -f2 | awk '{ print $1}'";
+                $ss = @exec($command, $arr, $ret);
+                $registerIp = isset($arr[0]) ? $arr[0] : null;
+            }
+        } elseif (isset($_SERVER) && isset($_SERVER['SERVER_ADDR'])) {
+            $registerIp = gethostbyaddr($_SERVER['SERVER_ADDR']);
+        }
+        if (empty($registerIp)) {
+            $registerIp = gethostbyname(gethostname());
+        }
+        if (empty($registerIp)) {
+            throw new DubboPhpException('We can\'t get your local ip address.');
+        }
+        return $registerIp;
+    }
+
+}

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,0 +1,31 @@
+<?php
+return [
+
+    'default'=>[
+        /**
+         * zookeeper service address (host:port) default localhost:2181
+         */
+        'registry_address' => env('ZOOKEEPER_ADDRESS','localhost:2181'),
+
+        /**
+         * service provider invoke timeout
+         */
+        'provider_timeout' => 5, //seconds
+
+        /**
+         * service version
+         */
+        'version' => '0.0.0',
+        /**
+         * service group name
+         */
+        'group' => null,
+        /**
+         * protocol support jsonrpc/hessian(undone)
+         */
+        'protocol' => 'jsonrpc',
+    ],
+
+    'connections'=>[
+    ],
+];

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -15,7 +15,7 @@ return [
         /**
          * service version
          */
-        'version' => '0.0.0',
+        'version' => '1.0.0',
         /**
          * service group name
          */

--- a/src/register.php
+++ b/src/register.php
@@ -212,8 +212,8 @@ class Register{
             $registerIp = null;
             if(php_sapi_name()=='cli'){
                 if (substr(strtolower(PHP_OS), 0, 3) != 'win') {
-                    $command="/sbin/ifconfig eth0 | grep 'inet' | cut -d: -f2 | awk '{ print $1}'";
-                    $ss = exec($command,$arr);
+                    $command="/sbin/ifconfig eth0 2>&1 | grep 'inet' | cut -d: -f2 | awk '{ print $1}'";
+                    $ss = @exec($command,$arr,$ret);
                     $registerIp = isset($arr[0])?$arr[0]:null;
                 }
             }elseif(isset($_SERVER) && isset($_SERVER['SERVER_ADDR'])){

--- a/src/register.php
+++ b/src/register.php
@@ -220,7 +220,7 @@ class Register{
                 $registerIp = gethostbyaddr($_SERVER['SERVER_ADDR']);
             }
             if (empty($registerIp)) {
-                $registerIp = getHostByName(getHostName());
+                $registerIp = gethostbyname(gethostname());
             }
         }catch (\Exception $e){
             error_log("We can't get your local ip address.\n");

--- a/src/register.php
+++ b/src/register.php
@@ -74,7 +74,7 @@ class Register{
         $providerHost = $this->providersCluster->getProvider($invokDesc);
         $invoker->setHost(Invoker::genDubboUrl($providerHost,$invokDesc));
         $registerNode = $this->makeRegistryNode($invokDesc->getService());
-        try {
+//        try {
             $parts = explode('/', $registerNode);
             $parts = array_filter($parts);
             $subpath = '';
@@ -87,9 +87,9 @@ class Register{
             if(!$this->zookeeper->exists($registerNode)) {
                 $this->zookeeper->create($registerNode, '', $this->acl, null);
             }
-        }catch (ZookeeperNoNodeException $ze){
-            error_log("This zookeeper node does not exsit.Please check the zookeeper node information.");
-        }
+//        }catch (ZookeeperNoNodeException $ze){
+//            error_log("This zookeeper node does not exsit.Please check the zookeeper node information.");
+//        }
         return true;
     }
 
@@ -208,7 +208,7 @@ class Register{
      * we will get from the command.
      */
     private function achieveRegisterIp(){
-        try {
+//        try {
             $registerIp = null;
             if(php_sapi_name()=='cli'){
                 if (substr(strtolower(PHP_OS), 0, 3) != 'win') {
@@ -222,10 +222,11 @@ class Register{
             if (empty($registerIp)) {
                 $registerIp = gethostbyname(gethostname());
             }
-        }catch (\Exception $e){
-            error_log("We can't get your local ip address.\n");
-            error_log($e->getMessage()."\n");
-        }
+//        }catch (\Exception $e){
+//            error_log("We can't get your local ip address.\n");
+//            error_log($e->getMessage()."\n");
+//
+//        }
         return $registerIp;
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace DubboPhp\Client\Tests;
+
+use DubboPhp\Client\Client;
+
+class TestCase extends \PHPUnit_Framework_TestCase
+{
+
+    public function setUp()
+    {
+        parent::setUp();
+        require_once __DIR__.'/../vendor/autoload.php';
+    }
+    public function tearDown()
+    {
+        parent::tearDown();
+    }
+
+    public function testDefault()
+    {
+        $this->assertEquals(1,1*1);
+
+        $options = [
+            'registry_address' => '127.0.0.1:2181',
+            'version' => '1.0.0',
+            'group' =>null,
+            'protocol' => 'jsonrpc'
+        ];
+
+        try {
+            $dubboCli = new Client($options);
+            $testService = $dubboCli->getService("com.dubbo.demo.HelloService");
+            $ret = $testService->hello("dubbo php client");
+            $this->assertEquals('Hello, dubbo php client!',$ret);
+            $mapRet = $testService->mapEcho();
+            $this->assertEquals([
+                'key1'=>'Hello',
+                'key2'=>'World',
+            ],$mapRet);
+            $objectRet = $testService->objectEcho();
+            $this->assertEquals([
+                'key1'=>'hello world',
+                'key2'=>'2016',
+            ],$objectRet);
+            /**
+             * getService method support 2 way. If the forceVgp = true, It will assign the function parameter to service version,group and protocol. Default way is assign the $options configs to these.
+             * getService支持两种方式调用。如果forceVgp=true, 该方法将使用传参来绑定服务的版本号，组和协议。默认方式是使用$options数组里的配置绑定。
+             */
+            $testServiceWithvgp = $dubboCli->getService("com.dubbo.demo.HelloService","1.0.0",null, $forceVgp = true);
+            $vgpRet = $testServiceWithvgp->hello("this request from vgp");
+            $this->assertEquals('Hello, this request from vgp!',$vgpRet);
+        } catch (\Exception $e) {
+            print($e->getMessage());
+        }
+
+    }
+}


### PR DESCRIPTION
按composer规范代码重构，编写单元测试，支持laravel包调用

重构了整体的代码结构，
重新配置了composer.json的命名空间等支持
编写单元测试
支持作为Laravel组件模式使用
config/app.php的providers数组中增加DubboPhp\Client\DubboPhpClientServiceProvider::class后
命令行执行
php artisan vendor:publish --provider="DubboPhp\Client\DubboPhpClientServiceProvider"

代码中可以直接使用DubboPhpClient::getService做调用
$testService = DubboPhpClient::getService('com.dubbo.demo.HelloService');
$ret = $testService->hello("dubbo php client");

非laravel框架单独组件调用就
use DubboPhp\Client\Client;
$dubboCli = new Client($options);

在laravel内注册过
DubboPhp\Client\DubboPhpClientServiceProvider::class 服务提供者
和门面别名
'DubboPhpClient'=>DubboPhp\Client\Facades\DubboPhpClient::class,
'DubboPhpClientFactory'=>DubboPhp\Client\Facades\DubboPhpClientFactory::class,
后,
可以直接
单实例方式（配置读取config('dubbo_cli.default')）：
$testService = DubboPhpClient::getService('com.dubbo.demo.HelloService');
或者多实例的方式（配置读取config('dubbo_cli.connections.xxx')）：
$testService = DubboPhpClientFactory::factory(config('dubbo_cli.connections.xxx'))->getService('com.dubbo.demo.HelloService');
做处理，

具体见更新后的README.md后半部分
