### PR TITLE
解决服务端provider提供多种protocol类型服务时invoker调用的问题

### DIFF
--- a/src/DubboPhp/Client/Client.php
+++ b/src/DubboPhp/Client/Client.php
@@ -50,7 +50,6 @@ class Client
         $serviceVersion = !$forceVgp ? $this->register->getServiceVersion() : $version;
         $serviceGroup = !$forceVgp ? $this->register->getServiceGroup() : $group;
         $serviceProtocol = !$forceVgp ? $this->register->getServiceProtocol() : $protocol;
-
         $invokerDesc = new InvokerDesc($serviceName, $serviceVersion, $serviceGroup);
         $invoker = $this->register->getInvoker($invokerDesc);
         if(!$invoker){

--- a/src/DubboPhp/Client/InvokerDesc.php
+++ b/src/DubboPhp/Client/InvokerDesc.php
@@ -16,10 +16,11 @@ class InvokerDesc
     private $version ;
     private $schema = 'jsonrpc';
 
-    public function __construct($serviceName, $version=null, $group=null){
+    public function __construct($serviceName, $version=null, $group=null,$schema='jsonrpc'){
         $this->serviceName = $serviceName ;
         $this->version = $version;
         $this->group = $group;
+        !empty($schema) && $this->schema = $schema;
     }
 
     public function getService(){
@@ -37,12 +38,12 @@ class InvokerDesc
         return $this->serviceName.'_'.$group_str.'_'.$version_str.'_'.$this->schema;
     }
 
-    public function isMatch($group,$version){
-        return $this->group === $group && $this->version === $version;
+    public function isMatch($group,$version,$schema='jsonrpc'){
+        return $this->group === $group && $this->version === $version && $this->schema === $schema;
     }
 
     public function isMatchDesc($desc){
-        return $this->group == $desc->group && $this->version == $desc->version;
+        return $this->group == $desc->group && $this->version == $desc->version && $this->schema == $desc->schema;
     }
 
 }

--- a/src/DubboPhp/Client/Protocols/Hessian.php
+++ b/src/DubboPhp/Client/Protocols/Hessian.php
@@ -15,6 +15,9 @@ class Hessian extends Invoker
 {
     public function __construct($url=null, $debug=false)
     {
+        //@todo implement method
+        throw new DubboPhpException('Protocol not implemented yet.');
+
         parent::__construct($url,$debug);
     }
 

--- a/src/DubboPhp/Client/Protocols/Jsonrpc.php
+++ b/src/DubboPhp/Client/Protocols/Jsonrpc.php
@@ -47,6 +47,9 @@ class Jsonrpc extends Invoker{
             'id' => $currentId
         );
         $request = json_encode($request);
+        // curl -i -H 'content-type: application/json' -X POST -d '{"jsonrpc": "2.0", "method": "hello", "params": [ "World"],"id": 1 , "version":"1.0.0"}' 'http://127.0.0.1:8080/com.dubbo.demo.HelloService'
+        //echo 'curl -i -H \'content-type: application/json\' -X POST -d \''.$request.'\' \''.$this->url.'\''.PHP_EOL;
+
         $this->debug && $this->debug.='***** Request *****'."\n".$request."\n".'***** End Of request *****'."\n\n";
 
         $ch = curl_init();

--- a/src/DubboPhp/Client/Protocols/Jsonrpc.php
+++ b/src/DubboPhp/Client/Protocols/Jsonrpc.php
@@ -61,8 +61,8 @@ class Jsonrpc extends Invoker{
 
         $responseContent = curl_exec($ch);
         $curlErrorCode = curl_errno($ch);
-        curl_close($ch);
         $curlErrorMessage = curl_error($ch);
+        curl_close($ch);
 //        echo '$curlErrorCode:'.$curlErrorCode.PHP_EOL;
 //        echo '$curlErrorMessage:'.$curlErrorMessage.PHP_EOL;
 //        echo '$responseContent:'.PHP_EOL.$responseContent.PHP_EOL;

--- a/src/DubboPhp/Client/Protocols/Jsonrpc.php
+++ b/src/DubboPhp/Client/Protocols/Jsonrpc.php
@@ -46,10 +46,9 @@ class Jsonrpc extends Invoker{
             'params' => $params,
             'id' => $currentId
         );
-        $request = json_encode($request);
         // curl -i -H 'content-type: application/json' -X POST -d '{"jsonrpc": "2.0", "method": "hello", "params": [ "World"],"id": 1 , "version":"1.0.0"}' 'http://127.0.0.1:8080/com.dubbo.demo.HelloService'
-        //echo 'curl -i -H \'content-type: application/json\' -X POST -d \''.$request.'\' \''.$this->url.'\''.PHP_EOL;
-
+//        echo 'curl -i -H \'content-type: application/json\' -X POST -d \''.json_encode($request).'\' \''.$this->url.'\''.PHP_EOL;
+        $request = json_encode($request);
         $this->debug && $this->debug.='***** Request *****'."\n".$request."\n".'***** End Of request *****'."\n\n";
 
         $ch = curl_init();
@@ -62,8 +61,12 @@ class Jsonrpc extends Invoker{
 
         $responseContent = curl_exec($ch);
         $curlErrorCode = curl_errno($ch);
-        $curlErrorMessage = curl_error($ch);
         curl_close($ch);
+        $curlErrorMessage = curl_error($ch);
+//        echo '$curlErrorCode:'.$curlErrorCode.PHP_EOL;
+//        echo '$curlErrorMessage:'.$curlErrorMessage.PHP_EOL;
+//        echo '$responseContent:'.PHP_EOL.$responseContent.PHP_EOL;
+        
         if ($responseContent === FALSE)  {
             throw new DubboPhpException('Unable to connect to '.$this->url.' :'.$curlErrorMessage,$curlErrorCode);
         }

--- a/src/DubboPhp/Client/Register.php
+++ b/src/DubboPhp/Client/Register.php
@@ -112,7 +112,8 @@ class Register
         parse_str($schemeInfo['query'], $providerConfig);
         $group = isset($providerConfig['group']) ? $providerConfig['group'] : null;
         $version = isset($providerConfig['version']) ? $providerConfig['version'] : null;
-        if ($invokerDesc->isMatch($group, $version)) {
+        $protocol = isset($schemeInfo['scheme']) ? $schemeInfo['scheme'] : null;
+        if ($invokerDesc->isMatch($group, $version,$protocol)) {
             $this->providersCluster->addProvider($invokerDesc,
                 'http://' . $schemeInfo['host'] . ':' . $schemeInfo['port'], $schemeInfo['scheme']);
         }


### PR DESCRIPTION
当服务端提供单一service的多种provider的时候,现有的invokerdesc没有区分protocol/scheme，会照成调用hessian2协议的provider的问题导致无响应。